### PR TITLE
Feature/do everything in reusable workflow

### DIFF
--- a/.github/workflows/build-push-cheeseshop-image.yaml
+++ b/.github/workflows/build-push-cheeseshop-image.yaml
@@ -18,59 +18,42 @@ on:
   workflow_dispatch:
 
 jobs:
-  get-next-tag-version:
-    runs-on: ubuntu-latest
-    name: Get the next version of the tag
-    outputs:
-      next-tag: ${{ steps.get_next_tag.outputs.new_tag }}
-    steps:
-      - uses: actions/checkout@v2
+  # get-next-tag-version:
+  #   runs-on: ubuntu-latest
+  #   name: Get the next version of the tag
+  #   outputs:
+  #     next-tag: ${{ steps.get_next_tag.outputs.new_tag }}
+  #   steps:
+  #     - uses: actions/checkout@v2
       
-      - name: Get the next version of the tag
-        id: get_next_tag
-        uses: mathieudutour/github-tag-action@v6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # DO NOT create Git tag. Just calculate new tag version.
-          dry_run: true
-          default_bump: minor
-          default_prerelease_bump: preminor
-          # Helps avoid duplicate Docker image tags when two branches are created from same master commit.
-          append_to_pre_release_tag: ${{ format('{0}.{1}', github.actor, github.sha) }}
+  #     - name: Get the next version of the tag
+  #       id: get_next_tag
+  #       uses: mathieudutour/github-tag-action@v6.0
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         # DO NOT create Git tag. Just calculate new tag version.
+  #         dry_run: true
+  #         default_bump: minor
+  #         default_prerelease_bump: preminor
+  #         # Helps avoid duplicate Docker image tags when two branches are created from same master commit.
+  #         append_to_pre_release_tag: ${{ format('{0}.{1}', github.actor, github.sha) }}
         
-      - name: Debug
-        shell: bash
-        run: |
-          echo "Current Latest Tag: $tag"
-          echo "Github ref: ${{ github.ref }}"
-          echo "Pull Req Base Ref: ${{ github.event.pull_request.base.ref }}"
-        env:
-          tag: ${{ steps.get_next_tag.outputs.new_tag }}
+      # - name: Debug
+      #   shell: bash
+      #   run: |
+      #     echo "Current Latest Tag: $tag"
+      #     echo "Github ref: ${{ github.ref }}"
+      #     echo "Pull Req Base Ref: ${{ github.event.pull_request.base.ref }}"
+      #   env:
+      #     tag: ${{ steps.get_next_tag.outputs.new_tag }}
 
 
   # This is the actual calling job that calls the reusable workflow - to push image into DockerDev-Enp Artifactory Repo.
-  dockerdev-enp-push:
-    if: ${{ github.ref != 'master' && github.ref != 'refs/heads/master' }}
-    needs: [ get-next-tag-version ]
+  invoke-docker-build-push-reusable-workflow:
     uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@master
     with:
-      docker_registry: dockerdev-enp.bin.cloud.barco.com
-      docker_repo: varun
-      image_name: cheeseshop
-      image_tag: ${{ needs.get-next-tag-version.outputs.next-tag }}
-      build_directory: docker-cheeseshop
-      maintainer: "varun.charan@barco.com"
-    secrets:
-      registry_username: ${{ secrets.ARTIFACTORY_USERNAME }}
-      registry_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
-  
-  
-  # This is the actual calling job that calls the reusable workflow - to push image into Docker-Enp Artifactory Repo.
-  docker-enp-push:
-    if: ${{ github.ref == 'master' || github.ref == 'refs/heads/master' }}
-    needs: [ get-next-tag-version ]
-    uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@master
-    with:
+      app_github_repo: varun-charan/docker-cheeseshop
+      dockerdev_registry: dockerdev-enp.bin.cloud.barco.com
       docker_registry: docker-enp.bin.cloud.barco.com
       docker_repo: varun
       image_name: cheeseshop
@@ -80,23 +63,40 @@ jobs:
     secrets:
       registry_username: ${{ secrets.ARTIFACTORY_USERNAME }}
       registry_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+  
+  
+  # # This is the actual calling job that calls the reusable workflow - to push image into Docker-Enp Artifactory Repo.
+  # docker-enp-push:
+  #   if: ${{ github.ref == 'master' || github.ref == 'refs/heads/master' }}
+  #   needs: [ get-next-tag-version ]
+  #   uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@master
+  #   with:
+  #     docker_registry: docker-enp.bin.cloud.barco.com
+  #     docker_repo: varun
+  #     image_name: cheeseshop
+  #     image_tag: ${{ needs.get-next-tag-version.outputs.next-tag }}
+  #     build_directory: docker-cheeseshop
+  #     maintainer: "varun.charan@barco.com"
+  #   secrets:
+  #     registry_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+  #     registry_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
-  # # After a Docker image with the next version has been created, create a tag for the same in Git repo.
-  create-next-tag-version:
-    runs-on: ubuntu-latest
-    needs: [ get-next-tag-version, dockerdev-enp-push, docker-enp-push ]
-    if: |
-      always() &&
-      ( github.ref == 'master' || github.ref == 'refs/heads/master' ) &&
-      ( (needs.dockerdev-enp-push.result == 'success') || (needs.docker-enp-push.result == 'success') )
-    name: Create the next version of the tag
-    steps:
-      - uses: actions/checkout@v2
+  # # # After a Docker image with the next version has been created, create a tag for the same in Git repo.
+  # create-next-tag-version:
+  #   runs-on: ubuntu-latest
+  #   needs: [ get-next-tag-version, dockerdev-enp-push, docker-enp-push ]
+  #   if: |
+  #     always() &&
+  #     ( github.ref == 'master' || github.ref == 'refs/heads/master' ) &&
+  #     ( (needs.dockerdev-enp-push.result == 'success') || (needs.docker-enp-push.result == 'success') )
+  #   name: Create the next version of the tag
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ needs.get-next-tag-version.outputs.next-tag }}
-          name: ${{ needs.get-next-tag-version.outputs.next-tag }}
-          # Generates awesome release notes that you can edit later if you want.
-          generateReleaseNotes: true
+  #     - name: Create a GitHub release
+  #       uses: ncipollo/release-action@v1
+  #       with:
+  #         tag: ${{ needs.get-next-tag-version.outputs.next-tag }}
+  #         name: ${{ needs.get-next-tag-version.outputs.next-tag }}
+  #         # Generates awesome release notes that you can edit later if you want.
+  #         generateReleaseNotes: true

--- a/.github/workflows/build-push-cheeseshop-image.yaml
+++ b/.github/workflows/build-push-cheeseshop-image.yaml
@@ -50,7 +50,7 @@ jobs:
 
   # This is the actual calling job that calls the reusable workflow - to push image into DockerDev-Enp Artifactory Repo.
   invoke-docker-build-push-reusable-workflow:
-    uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@master
+    uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@feature/do-everything-with-reusable-workflow
     with:
       app_github_repo: varun-charan/docker-cheeseshop
       dockerdev_registry: dockerdev-enp.bin.cloud.barco.com

--- a/.github/workflows/build-push-cheeseshop-image.yaml
+++ b/.github/workflows/build-push-cheeseshop-image.yaml
@@ -49,7 +49,7 @@ jobs:
 
 
   # This is the actual calling job that calls the reusable workflow - to push image into DockerDev-Enp Artifactory Repo.
-  invoke-docker-build-push-reusable-workflow:
+  invoke-reusable-workflow:
     uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@feature/do-everything-with-reusable-workflow
     with:
       app_github_repo: varun-charan/docker-cheeseshop

--- a/.github/workflows/build-push-cheeseshop-image.yaml
+++ b/.github/workflows/build-push-cheeseshop-image.yaml
@@ -49,7 +49,7 @@ jobs:
 
 
   # This is the actual calling job that calls the reusable workflow - to push image into DockerDev-Enp Artifactory Repo.
-  invoke-reusable-workflow:
+  invoke-reusable:
     uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@feature/do-everything-with-reusable-workflow
     with:
       app_github_repo: varun-charan/docker-cheeseshop
@@ -57,7 +57,6 @@ jobs:
       docker_registry: docker-enp.bin.cloud.barco.com
       docker_repo: varun
       image_name: cheeseshop
-      image_tag: ${{ needs.get-next-tag-version.outputs.next-tag }}
       build_directory: docker-cheeseshop
       maintainer: "varun.charan@barco.com"
     secrets:

--- a/.github/workflows/build-push-cheeseshop-image.yaml
+++ b/.github/workflows/build-push-cheeseshop-image.yaml
@@ -18,41 +18,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  # get-next-tag-version:
-  #   runs-on: ubuntu-latest
-  #   name: Get the next version of the tag
-  #   outputs:
-  #     next-tag: ${{ steps.get_next_tag.outputs.new_tag }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-      
-  #     - name: Get the next version of the tag
-  #       id: get_next_tag
-  #       uses: mathieudutour/github-tag-action@v6.0
-  #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         # DO NOT create Git tag. Just calculate new tag version.
-  #         dry_run: true
-  #         default_bump: minor
-  #         default_prerelease_bump: preminor
-  #         # Helps avoid duplicate Docker image tags when two branches are created from same master commit.
-  #         append_to_pre_release_tag: ${{ format('{0}.{1}', github.actor, github.sha) }}
-        
-      # - name: Debug
-      #   shell: bash
-      #   run: |
-      #     echo "Current Latest Tag: $tag"
-      #     echo "Github ref: ${{ github.ref }}"
-      #     echo "Pull Req Base Ref: ${{ github.event.pull_request.base.ref }}"
-      #   env:
-      #     tag: ${{ steps.get_next_tag.outputs.new_tag }}
-
-
-  # This is the actual calling job that calls the reusable workflow - to push image into DockerDev-Enp Artifactory Repo.
+  # This is the actual calling job that calls the reusable workflow - to push image into Docker Artifactory Repo.
   invoke-reusable:
-    uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@feature/do-everything-with-reusable-workflow
+    uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@master
     with:
-      app_github_repo: varun-charan/docker-cheeseshop
       dockerdev_registry: dockerdev-enp.bin.cloud.barco.com
       docker_registry: docker-enp.bin.cloud.barco.com
       docker_repo: varun
@@ -62,40 +31,4 @@ jobs:
     secrets:
       registry_username: ${{ secrets.ARTIFACTORY_USERNAME }}
       registry_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
-  
-  
-  # # This is the actual calling job that calls the reusable workflow - to push image into Docker-Enp Artifactory Repo.
-  # docker-enp-push:
-  #   if: ${{ github.ref == 'master' || github.ref == 'refs/heads/master' }}
-  #   needs: [ get-next-tag-version ]
-  #   uses: varun-charan/reusable-workflows/.github/workflows/docker-build-push.yaml@master
-  #   with:
-  #     docker_registry: docker-enp.bin.cloud.barco.com
-  #     docker_repo: varun
-  #     image_name: cheeseshop
-  #     image_tag: ${{ needs.get-next-tag-version.outputs.next-tag }}
-  #     build_directory: docker-cheeseshop
-  #     maintainer: "varun.charan@barco.com"
-  #   secrets:
-  #     registry_username: ${{ secrets.ARTIFACTORY_USERNAME }}
-  #     registry_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
-
-  # # # After a Docker image with the next version has been created, create a tag for the same in Git repo.
-  # create-next-tag-version:
-  #   runs-on: ubuntu-latest
-  #   needs: [ get-next-tag-version, dockerdev-enp-push, docker-enp-push ]
-  #   if: |
-  #     always() &&
-  #     ( github.ref == 'master' || github.ref == 'refs/heads/master' ) &&
-  #     ( (needs.dockerdev-enp-push.result == 'success') || (needs.docker-enp-push.result == 'success') )
-  #   name: Create the next version of the tag
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - name: Create a GitHub release
-  #       uses: ncipollo/release-action@v1
-  #       with:
-  #         tag: ${{ needs.get-next-tag-version.outputs.next-tag }}
-  #         name: ${{ needs.get-next-tag-version.outputs.next-tag }}
-  #         # Generates awesome release notes that you can edit later if you want.
-  #         generateReleaseNotes: true
+      


### PR DESCRIPTION
Now calling workflow only has to call the called/reusable workflow once
Reusable workflow determines new tag, builds and pushes image with new tag and created the tag as a release in Github.
Works as per branch - feature/hotfix branches create only dev docker image and master branch creates prd docker image.